### PR TITLE
Prerender 404 support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import { PrerenderLambda } from "./lib/prerender-lambda-construct";
 import { PrerenderFunction } from "./lib/prerender-construct";
 import { PrerenderCheckFunction } from "./lib/prerender-check-construct";
+import { ErrorResponseFunction } from "./lib/error-response-construct";
 
-export { PrerenderLambda, PrerenderFunction, PrerenderCheckFunction };
+export { PrerenderLambda, PrerenderFunction, PrerenderCheckFunction, ErrorResponseFunction };

--- a/lib/error-response-construct.ts
+++ b/lib/error-response-construct.ts
@@ -1,0 +1,39 @@
+import { Construct } from "@aws-cdk/core";
+import { Bundling } from '@aws-cdk/aws-lambda-nodejs/lib/bundling';
+import { Runtime } from '@aws-cdk/aws-lambda';
+import { experimental } from '@aws-cdk/aws-cloudfront';
+import { EdgeFunction } from "@aws-cdk/aws-cloudfront/lib/experimental";
+
+export interface ErrorResponseFunctionOptions {
+    redirectFrontendHost: string,
+}
+
+export class ErrorResponseFunction extends Construct {
+    readonly edgeFunction: EdgeFunction;
+
+    constructor(scope: Construct, id: string, options: ErrorResponseFunctionOptions) {
+        super(scope, id);
+
+        this.edgeFunction = new experimental.EdgeFunction(
+            this,
+            'ErrorResponseFunction',
+            {
+              code: Bundling.bundle({
+                entry: `${__dirname}/handlers/error-response.ts`,
+                runtime: Runtime.NODEJS_12_X,
+                sourceMap: true,
+                projectRoot: `${__dirname}/handlers/`,
+                depsLockFilePath: `${__dirname}/handlers/package-lock.json`,
+                // Define options replace values at build time so we can use environment variables to test locally
+                // and replace during build/deploy with static values. This gets around the lambda@edge limitation
+                // of no environment variables at runtime.
+                define: {
+                  'process.env.REDIRECT_FRONTEND_HOST': JSON.stringify(options.redirectFrontendHost),
+                }
+              }),
+              runtime: Runtime.NODEJS_12_X,
+              handler: 'index.handler',
+            }
+          );
+    }
+}

--- a/lib/handlers/error-response.ts
+++ b/lib/handlers/error-response.ts
@@ -28,7 +28,7 @@ export const handler = (event: CloudFrontResponseEvent): Promise<CloudFrontRespo
       request.uri != '/index.html') {
     
     // Fetch default page and return body
-    return instance.get('/index.html', { baseURL: REDIRECT_FRONTEND_HOST }).then((res) => {
+    return instance.get(`https://${REDIRECT_FRONTEND_HOST}/index.html`).then((res) => {
       response.body = res.data;
       response.headers['content-type'] = [{
         key: 'Content-Type',

--- a/lib/handlers/error-response.ts
+++ b/lib/handlers/error-response.ts
@@ -26,7 +26,9 @@ export const handler = (event: CloudFrontResponseEvent): Promise<CloudFrontRespo
   if (response.status != '200' && 
       ! request.headers['x-request-prerender'] &&
       request.uri != '/index.html') {
-    return instance.get(request.uri, { baseURL: REDIRECT_FRONTEND_HOST }).then((res) => {
+    
+    // Fetch default page and return body
+    return instance.get('/index.html', { baseURL: REDIRECT_FRONTEND_HOST }).then((res) => {
       response.body = res.data;
       response.headers['content-type'] = [{
         key: 'Content-Type',
@@ -34,9 +36,6 @@ export const handler = (event: CloudFrontResponseEvent): Promise<CloudFrontRespo
       }];
       return response;
     }).catch((err) => {
-      console.log(request.uri);
-      console.log(REDIRECT_FRONTEND_HOST);
-      console.log(err);
       return response
     });
   }

--- a/lib/handlers/error-response.ts
+++ b/lib/handlers/error-response.ts
@@ -30,10 +30,16 @@ export const handler = (event: CloudFrontResponseEvent): Promise<CloudFrontRespo
     // Fetch default page and return body
     return instance.get(`https://${REDIRECT_FRONTEND_HOST}/index.html`).then((res) => {
       response.body = res.data;
+
+      
       response.headers['content-type'] = [{
         key: 'Content-Type',
         value: 'text/html'
       }];
+
+      // Remove content-length if set as this may be the value from the origin.
+      delete response.headers['content-length']
+
       return response;
     }).catch((err) => {
       return response

--- a/lib/handlers/error-response.ts
+++ b/lib/handlers/error-response.ts
@@ -1,0 +1,45 @@
+import 'source-map-support/register';
+import { CloudFrontRequest, CloudFrontResponseEvent, CloudFrontResponse } from 'aws-lambda';
+import axios from "axios";
+import { URL } from 'url';
+import * as https from 'https';
+
+const REDIRECT_FRONTEND_HOST = process.env.REDIRECT_FRONTEND_HOST;
+
+// Create axios client outside of lambda function for re-use between calls
+const instance = axios.create({
+  timeout: 1000,
+  // Don't follow redirects
+  maxRedirects: 0,
+  // Only valid response codes are 200 
+  validateStatus: function (status) {
+    return status == 200;
+  },
+  // keep connection alive so we don't constantly do SSL negotiation
+  httpsAgent: new https.Agent({ keepAlive: true }),
+});
+
+export const handler = (event: CloudFrontResponseEvent): Promise<CloudFrontResponse|CloudFrontRequest> => {
+  let response = event.Records[0].cf.response;
+  let request = event.Records[0].cf.request;
+
+  if (response.status != '200' && 
+      ! request.headers['x-request-prerender'] &&
+      request.uri != '/index.html') {
+    return instance.get(request.uri, { baseURL: REDIRECT_FRONTEND_HOST }).then((res) => {
+      response.body = res.data;
+      response.headers['content-type'] = [{
+        key: 'Content-Type',
+        value: 'text/html'
+      }];
+      return response;
+    }).catch((err) => {
+      console.log(request.uri);
+      console.log(REDIRECT_FRONTEND_HOST);
+      console.log(err);
+      return response
+    });
+  }
+
+  return Promise.resolve(response);
+}

--- a/lib/handlers/prerender.ts
+++ b/lib/handlers/prerender.ts
@@ -45,7 +45,7 @@ export const handler = (event: CloudFrontRequestEvent): Promise<CloudFrontRespon
           ],
         }
     };
-  }).catch((_) => {
+  }).catch((err) => {
     // An error is returned when any status code except a 301 or 302
     // fallback to normal prerender behavior
 
@@ -76,13 +76,10 @@ export const handler = (event: CloudFrontRequestEvent): Promise<CloudFrontRespon
               }
           }
       };
-      return request;
    } else {
-       // When any error is returned, return out default response instead.
-       request.uri = '/index.html';
-
-       // Fallback to default behavior
-       return request;
+     request.uri = '/index.html';
    }
+
+   return request;
   });
 }

--- a/lib/handlers/prerender.ts
+++ b/lib/handlers/prerender.ts
@@ -76,11 +76,13 @@ export const handler = (event: CloudFrontRequestEvent): Promise<CloudFrontRespon
               }
           }
       };
+      return request;
    } else {
        // When any error is returned, return out default response instead.
        request.uri = '/index.html';
 
        // Fallback to default behavior
        return request;
+   }
   });
 }

--- a/lib/handlers/prerender.ts
+++ b/lib/handlers/prerender.ts
@@ -21,12 +21,12 @@ const instance = axios.create({
   httpsAgent: new https.Agent({ keepAlive: true }),
 });
 
-export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFrontResponse|CloudFrontRequest> => {
+export const handler = (event: CloudFrontRequestEvent): Promise<CloudFrontResponse|CloudFrontRequest> => {
   let request = event.Records[0].cf.request;
-  try {
-    // Make HEAD request to the Magento backend to see if there is a redirect for this path 
-    let response = await instance.head(request.uri, { baseURL: REDIRECT_BACKEND });
-    let location = new URL(response.headers.location);
+
+  // Make HEAD request to the Magento backend to see if there is a redirect for this path 
+  return instance.head(request.uri, { baseURL: REDIRECT_BACKEND }).then((res) => {
+    let location = new URL(res.headers.location);
 
     // if the host matches our magento backend replace it with the frontend url
     // this allows magento to perform full url redirects if needed.
@@ -35,8 +35,8 @@ export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFront
     }
 
     return <CloudFrontResponse>{
-        status: String(response.status),
-        statusDescription: response.statusText,
+        status: String(res.status),
+        statusDescription: res.statusText,
         headers: {
           Location: [
             {
@@ -45,8 +45,7 @@ export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFront
           ],
         }
     };
-
-  } catch (error) {
+  }).catch((_) => {
     // An error is returned when any status code except a 301 or 302
     // fallback to normal prerender behavior
 
@@ -77,8 +76,11 @@ export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFront
               }
           }
       };
-   }
-    // Fallback to default behavior
-    return request;
-  }
+   } else {
+       // When any error is returned, return out default response instead.
+       request.uri = '/index.html';
+
+       // Fallback to default behavior
+       return request;
+  });
 }

--- a/lib/prerender-lambda-construct.ts
+++ b/lib/prerender-lambda-construct.ts
@@ -1,6 +1,7 @@
 import { Construct, CfnOutput } from '@aws-cdk/core';
 import { PrerenderFunction } from './prerender-construct';
 import { PrerenderCheckFunction } from './prerender-check-construct';
+import { ErrorResponseFunction } from './error-response-construct';
 
 export interface PrerenderLambdaProps {
     redirectBackendOrigin: string,
@@ -22,6 +23,12 @@ export class PrerenderLambda extends Construct {
     new CfnOutput(this, 'PrerenderFunctionVersionARN', {
         description: 'PrerenderFunctionVersionARN',
         value: redirectFunction.edgeFunction.currentVersion.edgeArn,
+    });
+
+    const errorResponseFunction = new ErrorResponseFunction(this, 'ErrorResponse', props);
+    new CfnOutput(this, 'ErrorResponseVersionARN', {
+        description: 'ErrorResponseVersionARN',
+        value: errorResponseFunction.edgeFunction.currentVersion.edgeArn,
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aligent/aws-prerender-proxy-stack",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aligent/aws-prerender-proxy-stack",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@aws-cdk/aws-cloudfront": "^1.111.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-prerender-proxy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Cloudfront Lambda@Edge stack for integrating with prerender.io",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently, with most sites using the [static hosting construct](https://github.com/aligent/cdk-static-hosting), prerender 404s are not returned to the client as the CloudFormation error page was returned instead.

This pull request makes the following changes:
- The prerender origin request Lambda now returns the contents of `/index.html` for all non prerender.io requests. 
- A new function `ErrorResponseFunction` is added which essentially mimics the behaviour of a CloudFormation error page.