### PR TITLE
Add EXCLUSION_EXPRESSION option to origin request

### DIFF
--- a/lib/prerender-construct.ts
+++ b/lib/prerender-construct.ts
@@ -8,6 +8,7 @@ export interface PrerenderFunctionOptions {
     redirectBackendOrigin: string,
     redirectFrontendHost: string,
     prerenderToken: string
+    exclusionExpression?: string
 }
 
 export class PrerenderFunction extends Construct {
@@ -32,7 +33,8 @@ export class PrerenderFunction extends Construct {
                 define: {
                   'process.env.REDIRECT_BACKEND': JSON.stringify(options.redirectBackendOrigin),
                   'process.env.REDIRECT_FRONTEND_HOST': JSON.stringify(options.redirectFrontendHost),
-                  'process.env.PRERENDER_TOKEN': JSON.stringify(options.prerenderToken)
+                  'process.env.PRERENDER_TOKEN': JSON.stringify(options.prerenderToken),
+                  'process.env.EXCLUSION_EXPRESSION': JSON.stringify(options.exclusionExpression)
                 }
               }),
               runtime: Runtime.NODEJS_12_X,

--- a/lib/prerender-lambda-construct.ts
+++ b/lib/prerender-lambda-construct.ts
@@ -7,6 +7,7 @@ export interface PrerenderLambdaProps {
     redirectBackendOrigin: string,
     redirectFrontendHost: string,
     prerenderToken: string
+    exclusionExpression?: string
 }
 
 export class PrerenderLambda extends Construct {


### PR DESCRIPTION
Adds a parameter `EXCLUSION_EXPRESSION` to the prerender request construct which allows the exclusion of paths.