### PR TITLE
SD-1111: Removes Magento redirection

### DIFF
--- a/lib/error-response-construct.ts
+++ b/lib/error-response-construct.ts
@@ -5,7 +5,7 @@ import { experimental } from '@aws-cdk/aws-cloudfront';
 import { EdgeFunction } from "@aws-cdk/aws-cloudfront/lib/experimental";
 
 export interface ErrorResponseFunctionOptions {
-    redirectFrontendHost: string,
+    frontendHost: string,
     pathPrefix?: string
 }
 
@@ -29,7 +29,7 @@ export class ErrorResponseFunction extends Construct {
                 // and replace during build/deploy with static values. This gets around the lambda@edge limitation
                 // of no environment variables at runtime.
                 define: {
-                  'process.env.REDIRECT_FRONTEND_HOST': JSON.stringify(options.redirectFrontendHost),
+                  'process.env.REDIRECT_FRONTEND_HOST': JSON.stringify(options.frontendHost),
                   'process.env.PATH_PREFIX': JSON.stringify(options.pathPrefix ?? ''),
                 }
               }),

--- a/lib/handlers/error-response.ts
+++ b/lib/handlers/error-response.ts
@@ -4,7 +4,7 @@ import axios from "axios";
 import { URL } from 'url';
 import * as https from 'https';
 
-const REDIRECT_FRONTEND_HOST = process.env.REDIRECT_FRONTEND_HOST;
+const FRONTEND_HOST = process.env.FRONTEND_HOST;
 const PATH_PREFIX = process.env.PATH_PREFIX;
 
 // Create axios client outside of lambda function for re-use between calls
@@ -29,7 +29,7 @@ export const handler = (event: CloudFrontResponseEvent): Promise<CloudFrontRespo
       request.uri != `${PATH_PREFIX}/index.html`) {
     
     // Fetch default page and return body
-    return instance.get(`https://${REDIRECT_FRONTEND_HOST}${PATH_PREFIX}/index.html`).then((res) => {
+    return instance.get(`https://${FRONTEND_HOST}${PATH_PREFIX}/index.html`).then((res) => {
       response.body = res.data;
 
       

--- a/lib/handlers/prerender.ts
+++ b/lib/handlers/prerender.ts
@@ -7,11 +7,6 @@ const PATH_PREFIX = process.env.PATH_PREFIX;
 export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFrontResponse|CloudFrontRequest> => {
   let request = event.Records[0].cf.request;
 
-  if ((new RegExp(EXCLUSION_EXPRESSION)).test(request.uri)) {
-    request.uri = `${PATH_PREFIX}/index.html`;
-    request.uri = `${PATH_PREFIX}/index.html`;
-  }
-
   // viewer-request function will determine whether we prerender or not
   // if we should we add prerender as our custom origin
   if (request.headers['x-request-prerender']) {

--- a/lib/handlers/prerender.ts
+++ b/lib/handlers/prerender.ts
@@ -11,7 +11,6 @@ export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFront
 
   if ((new RegExp(EXCLUSION_EXPRESSION)).test(request.uri)) {
     request.uri = `${PATH_PREFIX}/index.html`;
-    console.log(JSON.stringify(request));
     return request;
   }
 

--- a/lib/handlers/prerender.ts
+++ b/lib/handlers/prerender.ts
@@ -1,94 +1,50 @@
 import 'source-map-support/register';
-import axios from "axios";
 import { CloudFrontRequest, CloudFrontRequestEvent, CloudFrontResponse } from 'aws-lambda';
-import { URL } from 'url';
-import * as https from 'https';
 
-const REDIRECT_BACKEND = process.env.REDIRECT_BACKEND;
 const REDIRECT_FRONTEND_HOST = process.env.REDIRECT_FRONTEND_HOST;
 const PRERENDER_TOKEN = process.env.PRERENDER_TOKEN;
 const EXCLUSION_EXPRESSION = process.env.EXCLUSION_EXPRESSION;
 const PATH_PREFIX = process.env.PATH_PREFIX;
 
-// Create axios client outside of lambda function for re-use between calls
-const instance = axios.create({
-  timeout: 1000,
-  // Don't follow redirects
-  maxRedirects: 0,
-  // Only valid response codes are redirects
-  validateStatus: function (status) {
-    return status == 301 || status == 302;
-  },
-  // keep connection alive so we don't constantly do SSL negotiation
-  httpsAgent: new https.Agent({ keepAlive: true }),
-});
-
-export const handler = (event: CloudFrontRequestEvent): Promise<CloudFrontResponse|CloudFrontRequest> => {
+export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFrontResponse|CloudFrontRequest> => {
   let request = event.Records[0].cf.request;
 
   if ((new RegExp(EXCLUSION_EXPRESSION)).test(request.uri)) {
     request.uri = `${PATH_PREFIX}/index.html`;
     console.log(JSON.stringify(request));
-    return Promise.resolve(request);
+    return request;
   }
 
-  // Make HEAD request to the Magento backend to see if there is a redirect for this path 
-  return instance.head(request.uri.replace(PATH_PREFIX, ''), { baseURL: REDIRECT_BACKEND }).then((res) => {
-    let location = new URL(res.headers.location);
+  // viewer-request function will determine whether we prerender or not
+  // if we should we add prerender as our custom origin
+  if (request.headers['x-request-prerender']) {
+       // Cloudfront will alter the request for / to /index.html
+       // since it is defined as the default root object
+       // we do not want to do this when prerendering the homepage
+       if (request.uri === `${PATH_PREFIX}/index.html`) {
+            request.uri = `${PATH_PREFIX}/`;
+       }
 
-    // if the host matches our magento backend replace it with the frontend url
-    // this allows magento to perform full url redirects if needed.
-    if (location.href.startsWith(REDIRECT_BACKEND)) {
-      location.host = REDIRECT_FRONTEND_HOST;
-      location.pathname = `${PATH_PREFIX}${location.pathname}`;
-    }
-
-    return <CloudFrontResponse>{
-        status: String(res.status),
-        statusDescription: res.statusText,
-        headers: {
-          Location: [
-            {
-              value: location.href
+       request.origin = {
+            custom: {
+                 domainName: 'service.prerender.io',
+                 port: 443,
+                 protocol: 'https',
+                 readTimeout: 20,
+                 keepaliveTimeout: 5,
+                 sslProtocols: ['TLSv1', 'TLSv1.1', 'TLSv1.2'],
+                 path: '/https%3A%2F%2F' + request.headers['x-prerender-host'][0].value,
+                 customHeaders: {
+                      'x-prerender-token': [{
+                           key: 'x-prerender-token',
+                           value: PRERENDER_TOKEN
+                      }]
+                 }
             }
-          ],
-        }
-    };
-  }).catch((err) => {
-    // An error is returned when any status code except a 301 or 302
-    // fallback to normal prerender behavior
+       };
+  } else {
+       request.uri = `${PATH_PREFIX}/index.html`;
+  }
 
-    // viewer-request function will determine whether we prerender or not
-    // if we should we add prerender as our custom origin
-    if (request.headers['x-request-prerender']) {
-      // Cloudfront will alter the request for / to /index.html
-      // since it is defined as the default root object
-      // we do not want to do this when prerendering the homepage
-      if (request.uri === `${PATH_PREFIX}/index.html`) {
-           request.uri = `${PATH_PREFIX}/`;
-      }
-
-      request.origin = {
-          custom: {
-              domainName: 'service.prerender.io',
-              port: 443,
-              protocol: 'https',
-              readTimeout: 20,
-              keepaliveTimeout: 5,
-              sslProtocols: ['TLSv1', 'TLSv1.1', 'TLSv1.2'],
-              path: '/https%3A%2F%2F' + request.headers['x-prerender-host'][0].value,
-              customHeaders: {
-                'x-prerender-token': [{
-                  key: 'x-prerender-token',
-                  value: PRERENDER_TOKEN
-                }]
-              }
-          }
-      };
-   } else {
-     request.uri = `${PATH_PREFIX}/index.html`;
-   }
-
-   return request;
-  });
+  return request;
 }

--- a/lib/prerender-construct.ts
+++ b/lib/prerender-construct.ts
@@ -5,7 +5,6 @@ import { experimental } from '@aws-cdk/aws-cloudfront';
 import { EdgeFunction } from "@aws-cdk/aws-cloudfront/lib/experimental";
 
 export interface PrerenderFunctionOptions {
-    redirectBackendOrigin: string,
     redirectFrontendHost: string,
     prerenderToken: string
     exclusionExpression?: string
@@ -32,7 +31,6 @@ export class PrerenderFunction extends Construct {
                 // and replace during build/deploy with static values. This gets around the lambda@edge limitation
                 // of no environment variables at runtime.
                 define: {
-                  'process.env.REDIRECT_BACKEND': JSON.stringify(options.redirectBackendOrigin),
                   'process.env.REDIRECT_FRONTEND_HOST': JSON.stringify(options.redirectFrontendHost),
                   'process.env.PRERENDER_TOKEN': JSON.stringify(options.prerenderToken),
                   'process.env.PATH_PREFIX': JSON.stringify(options.pathPrefix ?? ''),

--- a/lib/prerender-lambda-construct.ts
+++ b/lib/prerender-lambda-construct.ts
@@ -4,7 +4,6 @@ import { PrerenderCheckFunction } from './prerender-check-construct';
 import { ErrorResponseFunction } from './error-response-construct';
 
 export interface PrerenderLambdaProps {
-    redirectBackendOrigin: string,
     redirectFrontendHost: string,
     prerenderToken: string
     exclusionExpression?: string

--- a/lib/prerender-lambda-construct.ts
+++ b/lib/prerender-lambda-construct.ts
@@ -4,6 +4,7 @@ import { PrerenderCheckFunction } from './prerender-check-construct';
 import { ErrorResponseFunction } from './error-response-construct';
 
 export interface PrerenderLambdaProps {
+    frontendHost: string,
     prerenderToken: string
     exclusionExpression?: string
 }

--- a/lib/prerender-lambda-construct.ts
+++ b/lib/prerender-lambda-construct.ts
@@ -4,7 +4,6 @@ import { PrerenderCheckFunction } from './prerender-check-construct';
 import { ErrorResponseFunction } from './error-response-construct';
 
 export interface PrerenderLambdaProps {
-    redirectFrontendHost: string,
     prerenderToken: string
     exclusionExpression?: string
 }
@@ -19,10 +18,10 @@ export class PrerenderLambda extends Construct {
         value: prerenderCheckFunction.edgeFunction.currentVersion.edgeArn,
     });
 
-    const redirectFunction = new PrerenderFunction(this, 'PrerenderOriginRequest', props);
+    const prerenderFunction = new PrerenderFunction(this, 'PrerenderOriginRequest', props);
     new CfnOutput(this, 'PrerenderFunctionVersionARN', {
         description: 'PrerenderFunctionVersionARN',
-        value: redirectFunction.edgeFunction.currentVersion.edgeArn,
+        value: prerenderFunction.edgeFunction.currentVersion.edgeArn,
     });
 
     const errorResponseFunction = new ErrorResponseFunction(this, 'ErrorResponse', props);


### PR DESCRIPTION
This PR removes the redirection logic which checks the redirect backend and returns the HTTP response code.

This is done as the preferred solution is for this is to provide a [prerender-status-code](https://docs.prerender.io/article/11-best-practices) in the payload.

This has **not** been tested yet.