### PR TITLE
Make lambda accessible from cdk-prerender-proxy

### DIFF
--- a/lib/prerender-lambda-construct.ts
+++ b/lib/prerender-lambda-construct.ts
@@ -9,25 +9,19 @@ export interface PrerenderLambdaProps {
 }
 
 export class PrerenderLambda extends Construct {
+
+  readonly  prerenderCheckFunction:PrerenderCheckFunction
+  readonly  prerenderFunction:PrerenderFunction
+  readonly  errorResponseFunction:ErrorResponseFunction
+
   constructor(scope: Construct, id: string, props: PrerenderLambdaProps) {
     super(scope, id);
 
-    const prerenderCheckFunction = new PrerenderCheckFunction(this, 'PrerenderViewerRequest');
-    new CfnOutput(this, 'PrerenderCheckVersionARN', {
-        description: 'PrerenderCheckVersionARN',
-        value: prerenderCheckFunction.edgeFunction.currentVersion.edgeArn,
-    });
+    this.prerenderCheckFunction = new PrerenderCheckFunction(this, 'PrerenderViewerRequest');
+   
+    this.prerenderFunction = new PrerenderFunction(this, 'PrerenderOriginRequest', props);
+    
+    this.errorResponseFunction = new ErrorResponseFunction(this, 'ErrorResponse', {});
 
-    const prerenderFunction = new PrerenderFunction(this, 'PrerenderOriginRequest', props);
-    new CfnOutput(this, 'PrerenderFunctionVersionARN', {
-        description: 'PrerenderFunctionVersionARN',
-        value: prerenderFunction.edgeFunction.currentVersion.edgeArn,
-    });
-
-    const errorResponseFunction = new ErrorResponseFunction(this, 'ErrorResponse', {});
-    new CfnOutput(this, 'ErrorResponseVersionARN', {
-        description: 'ErrorResponseVersionARN',
-        value: errorResponseFunction.edgeFunction.currentVersion.edgeArn,
-    });
   }
 }


### PR DESCRIPTION
- Make prerenderCheckFunction prerenderFunction errorResponseFunction available on the PrerenderLambda class.
- Remove the Cfn outputs from the construct (these should be done at the stack level)
Sample usage:
```
          /*
            Prerender Functions
            AU
          */
          const AuPrerenderLambda = new PrerenderLambda(this, 'au-prerender-lambda', stagingAuPrerenderProps);
          
          // Output - prerenderCheckFunction
          new CfnOutput(this, 'AUPrerenderCheckFunction', {
            description: 'au-prerender-check-function',
            value: AuPrerenderLambda.prerenderCheckFunction.edgeFunction.currentVersion.edgeArn,
          })
```
